### PR TITLE
Fix all lint errors and fix a deadlock

### DIFF
--- a/src/colours/models.rs
+++ b/src/colours/models.rs
@@ -5,7 +5,6 @@ use std::cmp::Ordering;
 
 use std::error::Error;
 use std::fmt::{Display, Error as FmtError, Formatter};
-use std::ops::Deref;
 use std::str::FromStr;
 
 use hsl::HSL;
@@ -105,12 +104,11 @@ pub struct ParsedColour<'a> {
 #[derive(Clone, PartialEq, Debug)]
 pub enum SortMethod {
     HSL,
-    Distance,
 }
 
 impl<'a> ParsedColour<'a> {
     pub fn sort_list<T: Into<Self> + Clone>(colours: Vec<T>, method: SortMethod) -> Vec<Self> {
-        let mut colours: Vec<Self> = colours.iter().cloned().map(T::into).collect();
+        let colours: Vec<Self> = colours.iter().cloned().map(T::into).collect();
 
         match method {
             SortMethod::HSL => {
@@ -121,15 +119,15 @@ impl<'a> ParsedColour<'a> {
                 hsl_list.iter().map(|z| z.to_parsed()).collect()
             }
 
-            SortMethod::Distance => {
-                colours.sort_by(|a, b| {
-                    a.compute_distance(&b)
-                        .partial_cmp(&b.compute_distance(a))
-                        .unwrap_or(Ordering::Less)
-                });
+            // SortMethod::Distance => {
+            //     colours.sort_by(|a, b| {
+            //         a.compute_distance(&b)
+            //             .partial_cmp(&b.compute_distance(a))
+            //             .unwrap_or(Ordering::Less)
+            //     });
 
-                colours
-            }
+            //     colours
+            // }
         }
     }
 

--- a/src/commands/channels.rs
+++ b/src/commands/channels.rs
@@ -20,7 +20,7 @@ pub fn set_channel(cmd: CreateCommand) -> CreateCommand {
 }
 
 pub fn set_channel_exec(
-    ctx: &mut Context,
+    _: &mut Context,
     msg: &Message,
     mut args: Args,
 ) -> Result<(), CommandError> {

--- a/src/commands/lists.rs
+++ b/src/commands/lists.rs
@@ -8,6 +8,7 @@ use serenity::framework::standard::{CommandError, CreateCommand};
 use serenity::model::prelude::Message;
 use serenity::prelude::Context;
 use serenity::Error as SerenityError;
+use serenity::CACHE;
 
 /// Sends the colour list into the user's DMs.
 pub fn list_colours(cmd: CreateCommand) -> CreateCommand {
@@ -20,11 +21,7 @@ pub fn list_colours(cmd: CreateCommand) -> CreateCommand {
         .exec(list_colours_exec)
 }
 
-pub fn list_colours_exec(
-    ctx: &mut Context,
-    msg: &Message,
-    _args: Args,
-) -> Result<(), CommandError> {
+pub fn list_colours_exec(_: &mut Context, msg: &Message, _args: Args) -> Result<(), CommandError> {
     let connection = utils::get_connection_or_panic();
 
     let guild = utils::get_guild_result(msg)?;
@@ -70,17 +67,21 @@ pub fn refresh_list(cmd: CreateCommand) -> CreateCommand {
         .usage("")
         .example("")
         .max_args(0)
-        .exec(list_colours_exec)
+        .exec(refresh_list_exec)
 }
 
-fn refresh_list_exec(ctx: &mut Context, msg: &Message, _args: Args) -> Result<(), CommandError> {
+fn refresh_list_exec(_: &mut Context, msg: &Message, _args: Args) -> Result<(), CommandError> {
     let connection = utils::get_connection_or_panic();
 
     let guild = utils::get_guild_result(msg)?;
     let guild = guild.read();
 
+    let cache = CACHE.read();
+    let self_id = cache.user.id.0;
+
     Ok(actions::guilds::update_channel_message(
-        guild.id,
+        guild,
+        self_id,
         &connection,
         true,
     )?)

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,6 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use failure::Error;
-use rocket;
 use toml;
 
 #[derive(Deserialize)]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,6 +11,6 @@ pub mod commands {
 }
 
 pub mod webserver {
-    pub const DISCORD_API_URL: &str = "https://discordapp.com/api/v6";
+    // pub const DISCORD_API_URL: &str = "https://discordapp.com/api/v6";
     // unused, but a reference for what the macro should be.
 }

--- a/src/dropdelete.rs
+++ b/src/dropdelete.rs
@@ -1,6 +1,7 @@
+/*
 use serenity::model::prelude::Message;
 use std::ops::{Deref, DerefMut};
-use std::thread::{self, sleep, spawn};
+use std::thread::{self, sleep};
 use std::time::Duration;
 
 pub struct DeleteOnDrop {
@@ -39,3 +40,4 @@ impl DerefMut for DeleteOnDrop {
         &mut self.message
     }
 }
+*/

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ extern crate hsl;
 extern crate hyper_native_tls;
 extern crate parallel_event_emitter;
 extern crate percent_encoding;
-#[macro_use]
 extern crate serde_urlencoded;
 #[macro_use]
 extern crate prettytable;
@@ -19,9 +18,7 @@ extern crate diesel;
 extern crate crossbeam;
 #[macro_use]
 extern crate derive_more;
-#[macro_use]
 extern crate rocket;
-#[macro_use]
 extern crate hyper;
 extern crate edit_distance;
 #[macro_use]
@@ -84,8 +81,6 @@ mod utils;
 mod webserver;
 
 use cleaner::Cleaner;
-// use collector::{Collector, CollectorItem, CollectorValue};
-use utils::Contextable;
 
 use std::thread;
 use std::time::Duration;
@@ -140,8 +135,6 @@ impl EventHandler for Handler {
             .map(|string| string.clone().to_string().to_lowercase())
             .map(|prefix| message.content.to_lowercase().starts_with(&prefix))
             .any(|id| id);
-
-        let emitted_message = message.clone();
 
         if message.author.bot {
             return;
@@ -293,7 +286,7 @@ fn create_framework() -> StandardFramework {
         .group("utils", |group| {
             group.command("info", commands::utils::info)
         })
-        .before(|ctx, msg, name| {
+        .before(|_, msg, name| {
             // culling help messages because they can flood the chat and dont delete themselves,
             // meaning they can linger in the colour channel.
             // therefore help messages only work in the dms.
@@ -327,7 +320,7 @@ fn create_framework() -> StandardFramework {
                 true
             }
         })
-        .after(|ctx, msg, cmd_name, res| {
+        .after(|_, msg, cmd_name, res| {
             // we're done with this message, sweep it.
             {
                 CLEANER.remove(&msg.id);

--- a/src/webserver/requests.rs
+++ b/src/webserver/requests.rs
@@ -1,13 +1,11 @@
 use webserver::graphql;
 
-use serde::{de::DeserializeOwned, Deserialize};
-use serde_json::{self, from_value, Value};
+use serde::de::DeserializeOwned;
+use serde_json;
 
 use failure::Error;
 use hyper::client::Response;
-use std::error::Error as ErrorTrait;
 use std::io::prelude::*;
-use webserver::graphql::GenericError;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "lowercase", untagged)]
@@ -24,15 +22,6 @@ impl<T> Into<Result<T, Error>> for DiscordResponse<T> {
             DiscordResponse::Error { message, .. } => Err(format_err!("{}", message)),
             DiscordResponse::OAuthError { error } => Err(format_err!("{}", error)),
         }
-    }
-}
-
-#[derive(Debug, Display)]
-pub struct DiscordError(pub String);
-
-impl ErrorTrait for DiscordError {
-    fn description(&self) -> &str {
-        &self.0
     }
 }
 

--- a/src/webserver/server.rs
+++ b/src/webserver/server.rs
@@ -5,8 +5,7 @@ use super::graphql;
 
 use rocket;
 use rocket::config::Config as RocketConfig;
-use rocket::http::Status;
-use rocket::request::{self, FromRequest, Outcome as RequestOutcome, Request};
+use rocket::request::{FromRequest, Outcome as RequestOutcome, Request};
 use rocket::response::content;
 use rocket::response::{NamedFile, Redirect};
 use rocket::State;


### PR DESCRIPTION
Changed update_channel_message to rely on data being supplied to the function instead of accessing the cache itself. Two reads into a RwLock on the same thread results in a deadlock, so now update_channel_message requires an additional argument, meaning that the function should only be accessing the cache once and passing the data down from once source

Possibilities:
* Just pass a cache object down instead
* Make the self_id: u64 a Option<u64> and then access the cache if option is None